### PR TITLE
Updated vignette links and fix typo

### DIFF
--- a/vignettes/Data_Exploration.Rmd
+++ b/vignettes/Data_Exploration.Rmd
@@ -156,6 +156,6 @@ Using base `R` instead of modules echoes the results of the modules we showed of
 
 ## Conclusion
 
-Data exploration is a crucial first step when performing a species distribution model analysis, but we are not yet ready to jump straight into fitting a model. Next we need to use the information we've gained from our exploration to select our covariates and prepare them for analysis. We explore this topic in the [Selecting and Preparing Covariates](https://rawgit.com/zoonproject/zoontutorials/master/docs/articles/Selecting_Covariates.html) guide.
+Data exploration is a crucial first step when performing a species distribution model analysis, but we are not yet ready to jump straight into fitting a model. Next we need to use the information we've gained from our exploration to select our covariates and prepare them for analysis. We explore this topic in the [Selecting and Preparing Covariates](Selecting_Covariates.html) guide.
 
 <hr>

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -167,7 +167,7 @@ We don't always need to process our data, in those instances, we can use the `No
 
 ### Step 4. Model
 
-The fourth argument of `workflow()` is `model`; this is where we choose our modelling method. There are many modelling methods to choose from and each have their merits [@elith06]. To help you choose which model module is right for your data, we've written a ['Choosing A Model' guide](Choosing_A_Model.html).
+The fourth argument of `workflow()` is `model`; this is where we choose our modelling method. There are many modelling methods to choose from and each have their merits [@elith06]. To help you choose which model module is right for your data, we've written a ['Choosing A Modellling Method' guide](Choosing_A_Modelling_Method.html).
 
 For now, let's work with the common modelling method logistic regression using the module `LogisticRegression`. We'll keep our data and process modules the same:
 

--- a/vignettes/Model_Validation.Rmd
+++ b/vignettes/Model_Validation.Rmd
@@ -115,7 +115,7 @@ This approach is in contrast to significance testing approaches that focus on se
 
 
 
-Information criteria build on deviance measures by penalising models for additional covariates. That is, they select for accurate and *parimsoneous* models.
+Information criteria build on deviance measures by penalising models for additional covariates. That is, they select for accurate and *parsimoneous* models.
 
 ### Cross-validation
 

--- a/vignettes/Selecting_Covariates.Rmd
+++ b/vignettes/Selecting_Covariates.Rmd
@@ -28,7 +28,7 @@ knitr::opts_chunk$set(message = FALSE,
 
 ## Introduction
 
-When we undertake a Species Distribution Model (SDM), a good first step is to explore our data to familiarise ourselves with its structure and limitations. We explore this topic in the [Data Exploration vignette](https://rawgit.com/zoonproject/zoontutorials/master/inst/doc/Selecting_Covariates.html). 
+When we undertake a Species Distribution Model (SDM), a good first step is to explore our data to familiarise ourselves with its structure and limitations. We explore this topic in the [Data Exploration vignette](Data_Exploration.html). 
 
 After exploring our data, and in conjunction with variable selection, if appropriate, we may want to implement various data processing steps into our `zoon` `workflow`. There are some generally agreed upon guidelines for this data processing, but it is also highly subjective and open to interpretation. This guide outlines a few suggested steps implemented in both base R as well as using `zoon`'s `output` and `process` modules for data processing. These include data cleaning, variable standardisation and transformation, and adding interaction terms (Figure 1).
 
@@ -227,6 +227,6 @@ process = addInteraction(which_covs = c('A', 'A', 'A'))
 
 ## Conclusion
 
-Now that we have processed our data and it is ready for analysis we have two potential next steps. If we are using presence-only data we will need to generate background points for most modelling methods. There are several aspects of this to consider and we explore them in our [Background Points]() **LINK TO BE ADDED WHEN POSSIBLE** guide. If we have presence-absence data then we can proceed to selecting an appropriate modelling method, and we explore this decision in our [Choosing A Modelling Method](https://cdn.rawgit.com/zoonproject/zoontutorials/58522d20/docs/articles/Choosing_A_Modelling_Method.html) guide.
+Now that we have processed our data and it is ready for analysis we have two potential next steps. If we are using presence-only data we will need to generate background points for most modelling methods. There are several aspects of this to consider and we explore them in our [Background Points](Background_Points.html) guide. If we have presence-absence data then we can proceed to selecting an appropriate modelling method, and we explore this decision in our [Choosing A Modelling Method](Choosing_A_Modelling_Method.html) guide.
 
 <hr>


### PR DESCRIPTION
Hi,
I was reading the tutorials and realized there were problems with links so I updated them all to be relative if that's ok?

I especially fixed the link of "Choose A Modelling Method" because the links were not updated after the change of name of the vignette from `Choose_A_Model.Rmd` to `Choose_A_Modelling_Method.Rmd`.